### PR TITLE
Remove commas from svg path definitions

### DIFF
--- a/src/system-flow-card.ts
+++ b/src/system-flow-card.ts
@@ -286,10 +286,10 @@ export class SystemFlowCard extends LitElement {
     }
 
     const svgLineMapByPosition = {
-      'left':   (pc, ipc)  => `M 100 ${ipc},  C 50 ${ipc},   50 ${pc},   0 ${pc}`,
-      'top':    (pc, ipc)  => `M ${ipc} 100,  C ${ipc} 50,   ${pc} 50,   ${pc} 0`,
-      'right':  (pc, ipc)  => `M 0 ${ipc},    C 50 ${ipc},   50 ${pc},   100 ${pc}`,
-      'bottom': (pc, ipc)  => `M ${ipc} 0,    C ${ipc} 50,   ${pc} 50,   ${pc} 100`,
+      'left':   (pc, ipc)  => `M 100 ${ipc}   C 50 ${ipc}    50 ${pc}    0 ${pc}`,
+      'top':    (pc, ipc)  => `M ${ipc} 100   C ${ipc} 50    ${pc} 50    ${pc} 0`,
+      'right':  (pc, ipc)  => `M 0 ${ipc}     C 50 ${ipc}    50 ${pc}    100 ${pc}`,
+      'bottom': (pc, ipc)  => `M ${ipc} 0     C ${ipc} 50    ${pc} 50    ${pc} 100`,
     };
 
     const avgSystemTotal = elements


### PR DESCRIPTION
Comma isn't valid in the d attribute of path elements and although it works in Chrome/Safari, it breaks in Firefox.

see https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path

This fixes #49